### PR TITLE
Enhancements to the snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -18,14 +18,18 @@ plugs:
     interface: content
     target: ffmpeg-platform
     default-provider: ffmpeg-2204
+  gnome-42-2204:
+    interface: content
+    target: gnome-platform
+    default-provider: gnome-42-2204
 
 apps:
   yt-dlp:
     command: bin/yt-dlp
     plugs: [home, network, network-bind, removable-media]
     environment:
-      LD_LIBRARY_PATH: $SNAP/ffmpeg-platform/usr/lib/$CRAFT_ARCH_TRIPLET
-      PATH: $SNAP/ffmpeg-platform/usr/bin:$PATH
+      LD_LIBRARY_PATH: $SNAP/ffmpeg-platform/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET/pulseaudio:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/lib/$CRAFT_ARCH_TRIPLET:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/lib:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET/dri
+      PATH: $SNAP/ffmpeg-platform/usr/bin:$SNAP/gnome-platform/usr/bin:$PATH
 
 parts:
   yt-dlp:
@@ -37,5 +41,4 @@ parts:
       craftctl set version=$(git describe --tags --abbrev=0)
     prime:
       - -share
-      - -pyvenv.cfg
       - -include

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,25 +10,32 @@ confinement: strict
 base: core22
 architectures:
   - build-on: amd64
+  # - build-on: arm64
+  # - build-on: armhf
+
+plugs:
+  ffmpeg-2204:
+    interface: content
+    target: ffmpeg-platform
+    default-provider: ffmpeg-2204
 
 apps:
   yt-dlp:
     command: bin/yt-dlp
     plugs: [home, network, network-bind, removable-media]
-
-environment:
-  "LD_LIBRARY_PATH": "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/blas:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/lapack:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
+    environment:
+      LD_LIBRARY_PATH: $SNAP/ffmpeg-platform/usr/lib/$CRAFT_ARCH_TRIPLET
+      PATH: $SNAP/ffmpeg-platform/usr/bin:$PATH
 
 parts:
   yt-dlp:
     plugin: python
     source: https://github.com/yt-dlp/yt-dlp.git
+    source-tag: '2023.10.13'
     override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version \
-      "$(git describe --long --tags --always --match=v*.*.* | sed 's/v//')"
-    stage-packages:
-      - libavdevice58
-      - libblas3
-      - ffmpeg
-      - libpulse0
+      craftctl default
+      craftctl set version=$(git describe --tags --abbrev=0)
+    prime:
+      - -share
+      - -pyvenv.cfg
+      - -include

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,8 +10,8 @@ confinement: strict
 base: core22
 architectures:
   - build-on: amd64
-  # - build-on: arm64
-  # - build-on: armhf
+  - build-on: arm64
+  - build-on: armhf
 
 plugs:
   ffmpeg-2204:
@@ -35,7 +35,7 @@ parts:
   yt-dlp:
     plugin: python
     source: https://github.com/yt-dlp/yt-dlp.git
-    source-tag: '2023.10.13'
+    #source-tag: '2023.10.13'
     override-pull: |
       craftctl default
       craftctl set version=$(git describe --tags --abbrev=0)


### PR DESCRIPTION
1. Using source-tag, to maintain proper version
2. Using ffmpeg content snap, which will reduce the snap size. We'll need an auto connection for this content snap. To test it locally, just run this before running.

```
sudo snap connect yt-dlp:ffmpeg-2204 ffmpeg-2204
```