### PR TITLE
install curl-cffi for browser impersonation support

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,6 +29,8 @@ parts:
     override-pull: |
       craftctl default
       craftctl set version=$(git describe --tags)
+    python-packages:
+      - curl-cffi>=0.11
     stage-packages:
       - libavdevice58
       - libblas3


### PR DESCRIPTION
Without curl_cffi, yt-dlp's --list-impersonate-targets shows every target (Chrome/Edge/Firefox/Safari/Tor) as unavailable, breaking sites that retry behind impersonation (Dailymotion, Cloudflare-fronted endpoints) and sites that require it unconditionally (Kick, Patreon, SoundCloud, etc.).

The >=0.11 pin covers all five targets including Tor. pip resolves to a wheel per build arch — armhf wheels exist from curl_cffi 0.14.0 onward (currently 0.15.0).

Fixes #11.

Assisted-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Tested-by: 林博仁(Buo-ren Lin) <buo.ren.lin@gmail.com>